### PR TITLE
changed the model naming code for multiple estimation

### DIFF
--- a/R/ggiplot.R
+++ b/R/ggiplot.R
@@ -264,10 +264,10 @@ ggiplot =
 					nms = paste('Group', seq_along(object))
 				}
 			}
-
-			nms = as.character(mapply(rep, nms, sapply(data, nrow)))
+			for(z in 1:length(data)){
+				data[[z]]$group = nms[[z]]
+			}
 			data = do.call('rbind', data)
-			data$group = nms
 			rownames(data) = NULL
 			if (length(unique(data$id))==1) {
 				fct_vars = ~ group

--- a/R/ggiplot.R
+++ b/R/ggiplot.R
@@ -264,9 +264,10 @@ ggiplot =
 					nms = paste('Group', seq_along(object))
 				}
 			}
-			for(z in 1:length(data)){
-				data[[z]]$group = nms[[z]]
+			for(zz in 1:length(data)){
+				data[[zz]]$group = nms[[zz]]
 			}
+			rm(zz)
 			data = do.call('rbind', data)
 			rownames(data) = NULL
 			if (length(unique(data$id))==1) {


### PR DESCRIPTION
Hi Grant,

The code currently has issues when running multiple estimation with different time samples. A very easy example to see this would be:

data(base_stagg)

est_twfe = feols(y ~ x1 + i(time_to_treatment, treated, ref = c(-1, -1000)) | id + year, base_stagg[base_stagg$year > 2, ])
est_sa20 = feols(y ~ x1 + sunab(year_treated, year) | id + year, base_stagg)

ggiplot(list('TWFE' = est_twfe, 'Sun & Abraham (2020)' = est_sa20),
        main = 'Staggered treatment', ref.line = -1, pt.join = TRUE)

I have changed the code so instead of using rep(), the code uses a for loop to name each estimation within a list of estimations. When running the same code above with the for loop, ggiplot produces an accurate graph. Let me know if this explanation is unclear.

Thank you,
Brock